### PR TITLE
Align ai2 API requests with legacy handling

### DIFF
--- a/ai2 (none working need to fix this!)/chat-init.js
+++ b/ai2 (none working need to fix this!)/chat-init.js
@@ -518,8 +518,8 @@ document.addEventListener("DOMContentLoaded", () => {
         );
         const selectedModel = modelSelect.value || currentSession.model || "unity";
         const nonce = Date.now().toString() + Math.random().toString(36).substring(2);
-        const body = { messages, model: selectedModel, nonce };
-        const apiUrl = `https://text.pollinations.ai/openai`;
+        const body = { messages, model: selectedModel, stream: false, nonce };
+        const apiUrl = `https://text.pollinations.ai/openai?safe=false`;
         console.log("Sending API request with payload:", JSON.stringify(body));
         fetch(apiUrl, {
             method: "POST",

--- a/ai2 (none working need to fix this!)/chat-storage.js
+++ b/ai2 (none working need to fix this!)/chat-storage.js
@@ -552,8 +552,8 @@ document.addEventListener("DOMContentLoaded", () => {
         );
         const selectedModel = modelSelect.value || currentSession.model || "unity";
         const nonce = Date.now().toString() + Math.random().toString(36).substring(2);
-        const body = { messages, model: selectedModel, nonce };
-        const apiUrl = `https://text.pollinations.ai/openai`;
+        const body = { messages, model: selectedModel, stream: false, nonce };
+        const apiUrl = `https://text.pollinations.ai/openai?safe=false`;
         console.log("Sending API request with payload:", JSON.stringify(body));
         fetch(apiUrl, {
             method: "POST",

--- a/ai2 (none working need to fix this!)/screensaver.js
+++ b/ai2 (none working need to fix this!)/screensaver.js
@@ -149,8 +149,8 @@ document.addEventListener("DOMContentLoaded", () => {
         const textModelSelect = document.getElementById("model-select");
         const selectedModel = textModelSelect?.value || (window.Storage?.getCurrentSession?.().model) || "unity";
 
-        const body = { messages, model: selectedModel, nonce: Date.now().toString() + Math.random().toString(36).substring(2) };
-        const apiUrl = `https://text.pollinations.ai/openai?seed=${seed}`;
+        const body = { messages, model: selectedModel, stream: false, nonce: Date.now().toString() + Math.random().toString(36).substring(2) };
+        const apiUrl = `https://text.pollinations.ai/openai?safe=false&seed=${seed}`;
         console.log("Sending API request for new prompt:", JSON.stringify(body));
 
         for (let attempt = 1; attempt <= maxRetries; attempt++) {


### PR DESCRIPTION
## Summary
- Add `stream: false` flag to ai2 API requests to avoid unexpected streaming responses
- Include `safe=false` query parameter in Pollinations API URLs for ai2 modules to mirror legacy behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c05e5937908329aa4d8a0000b41811