### PR TITLE
Add exponential retry for Pollinations text API calls

### DIFF
--- a/ai3/chat-core.js
+++ b/ai3/chat-core.js
@@ -1,3 +1,21 @@
+// Global helper to retry Pollinations text API requests with exponential backoff
+window.pollinationsFetch = async function(url, options = {}, retries = 6, delay = 4000) {
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        try {
+            const response = await fetch(url, options);
+            if (!response.ok) {
+                throw new Error(`Pollinations fetch failed with status ${response.status}`);
+            }
+            return response;
+        } catch (err) {
+            if (attempt === retries) throw err;
+            console.warn(`Pollinations fetch attempt ${attempt + 1} failed, retrying in ${delay/1000}s...`, err);
+            await new Promise(res => setTimeout(res, delay));
+            delay *= 2;
+        }
+    }
+};
+
 document.addEventListener("DOMContentLoaded", () => {
     window._pollinationsAPIConfig = {
         safe: false

--- a/ai3/chat-init.js
+++ b/ai3/chat-init.js
@@ -521,16 +521,13 @@ document.addEventListener("DOMContentLoaded", () => {
         const body = { messages, model: selectedModel, nonce };
         const apiUrl = `https://text.pollinations.ai/openai`;
         console.log("Sending API request with payload:", JSON.stringify(body));
-        fetch(apiUrl, {
+        window.pollinationsFetch(apiUrl, {
             method: "POST",
             headers: { "Content-Type": "application/json", Accept: "application/json" },
             body: JSON.stringify(body),
             cache: "no-store",
         })
-            .then(res => {
-                if (!res.ok) throw new Error(`Pollinations error: ${res.status}`);
-                return res.json();
-            })
+            .then(res => res.json())
             .then(data => {
                 console.log("API response received:", data);
                 loadingDiv.remove();

--- a/ai3/chat-storage.js
+++ b/ai3/chat-storage.js
@@ -555,16 +555,13 @@ document.addEventListener("DOMContentLoaded", () => {
         const body = { messages, model: selectedModel, nonce };
         const apiUrl = `https://text.pollinations.ai/openai`;
         console.log("Sending API request with payload:", JSON.stringify(body));
-        fetch(apiUrl, {
+        window.pollinationsFetch(apiUrl, {
             method: "POST",
             headers: { "Content-Type": "application/json", Accept: "application/json" },
             body: JSON.stringify(body),
             cache: "no-store",
         })
-            .then(res => {
-                if (!res.ok) throw new Error(`Pollinations error: ${res.status}`);
-                return res.json();
-            })
+            .then(res => res.json())
             .then(data => {
                 console.log("API response received:", data);
                 loadingDiv.remove();

--- a/ai3/ui.js
+++ b/ai3/ui.js
@@ -109,22 +109,12 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     function fetchPollinationsModels() {
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 5000);
-
-        fetch("https://text.pollinations.ai/models", {
+        window.pollinationsFetch("https://text.pollinations.ai/models", {
             method: "GET",
             headers: { "Content-Type": "application/json" },
-            cache: "no-store",
-            signal: controller.signal
+            cache: "no-store"
         })
-            .then(res => {
-                clearTimeout(timeoutId);
-                if (!res.ok) {
-                    throw new Error(`HTTP error! Status: ${res.status}`);
-                }
-                return res.json();
-            })
+            .then(res => res.json())
             .then(models => {
                 modelSelect.innerHTML = "";
                 let hasValidModel = false;
@@ -187,12 +177,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
             })
             .catch(err => {
-                clearTimeout(timeoutId);
-                if (err.name === "AbortError") {
-                    console.error("Fetch timed out");
-                } else {
-                    console.error("Failed to fetch text models:", err);
-                }
+                console.error("Failed to fetch text models:", err);
                 modelSelect.innerHTML = "";
                 const fallbackOpt = document.createElement("option");
                 fallbackOpt.value = "unity";


### PR DESCRIPTION
## Summary
- add global `pollinationsFetch` helper with 6 retry exponential backoff
- refactor all text.pollinations.ai requests to use new retry helper
- streamline screensaver prompt fetch logic

## Testing
- `node --check chat-core.js`
- `node --check ui.js`
- `node --check screensaver.js`
- `node --check chat-init.js`
- `node --check chat-storage.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c07021a5348329bc585c6808e27640