### PR TITLE
Handle Unity commands with retry logic

### DIFF
--- a/ai3/ui.js
+++ b/ai3/ui.js
@@ -108,37 +108,42 @@ document.addEventListener("DOMContentLoaded", () => {
         changeTheme(themeSelectSettings.value);
     });
 
-    function fetchPollinationsModels() {
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 5000);
+    async function fetchWithRetry(url, options = {}, retries = 6, delay = 4000) {
+        for (let attempt = 0; attempt <= retries; attempt++) {
+            try {
+                const res = await fetch(url, options);
+                if (!res.ok) throw new Error(`HTTP error! Status: ${res.status}`);
+                return res;
+            } catch (err) {
+                if (attempt === retries) throw err;
+                const wait = delay * Math.pow(2, attempt);
+                console.warn(`Fetch attempt ${attempt + 1} failed. Retrying in ${wait / 1000}s...`, err);
+                await new Promise(r => setTimeout(r, wait));
+            }
+        }
+    }
 
-        fetch("https://text.pollinations.ai/models", {
-            method: "GET",
-            headers: { "Content-Type": "application/json" },
-            cache: "no-store",
-            signal: controller.signal
-        })
-            .then(res => {
-                clearTimeout(timeoutId);
-                if (!res.ok) {
-                    throw new Error(`HTTP error! Status: ${res.status}`);
-                }
-                return res.json();
-            })
-            .then(models => {
-                modelSelect.innerHTML = "";
-                let hasValidModel = false;
+    async function fetchPollinationsModels() {
+        try {
+            const res = await fetchWithRetry("https://text.pollinations.ai/models", {
+                method: "GET",
+                headers: { "Content-Type": "application/json" },
+                cache: "no-store"
+            });
+            const models = await res.json();
+            modelSelect.innerHTML = "";
+            let hasValidModel = false;
 
-                if (!Array.isArray(models) || models.length === 0) {
-                    console.error("Models response is not a valid array or is empty:", models);
-                    throw new Error("Invalid models response");
-                }
+            if (!Array.isArray(models) || models.length === 0) {
+                console.error("Models response is not a valid array or is empty:", models);
+                throw new Error("Invalid models response");
+            }
 
-                models.forEach(m => {
-                    if (m && m.name && m.type !== "safety") {
-                        const opt = document.createElement("option");
-                        opt.value = m.name;
-                        opt.textContent = m.description || m.name;
+            models.forEach(m => {
+                if (m && m.name && m.type !== "safety") {
+                    const opt = document.createElement("option");
+                    opt.value = m.name;
+                    opt.textContent = m.description || m.name;
 
                         let tooltip = m.description || m.name;
                         if (m.censored !== undefined) {
@@ -155,60 +160,54 @@ document.addEventListener("DOMContentLoaded", () => {
                     } else {
                         console.warn("Skipping invalid model entry:", m);
                     }
-                });
+            });
 
-                if (!hasValidModel) {
-                    const fallbackOpt = document.createElement("option");
-                    fallbackOpt.value = "unity";
-                    fallbackOpt.textContent = "unity";
-                    modelSelect.appendChild(fallbackOpt);
-                    modelSelect.value = "unity";
-                }
-
-                const currentSession = Storage.getCurrentSession();
-                if (currentSession && currentSession.model) {
-                    const modelExists = Array.from(modelSelect.options).some(option => option.value === currentSession.model);
-                    if (modelExists) {
-                        modelSelect.value = currentSession.model;
-                    } else {
-                        const tempOpt = document.createElement("option");
-                        tempOpt.value = currentSession.model;
-                        tempOpt.textContent = `${currentSession.model} (Previously Selected - May Be Unavailable)`;
-                        tempOpt.title = "This model may no longer be available";
-                        modelSelect.appendChild(tempOpt);
-                        modelSelect.value = currentSession.model;
-                        console.warn(`Model ${currentSession.model} not found in fetched list. Added as unavailable option.`);
-                    }
-                } else {
-                    const unityOptionExists = Array.from(modelSelect.options).some(option => option.value === "unity");
-                    if (unityOptionExists) {
-                        modelSelect.value = "unity";
-                    }
-                }
-            })
-            .catch(err => {
-                clearTimeout(timeoutId);
-                if (err.name === "AbortError") {
-                    console.error("Fetch timed out");
-                } else {
-                    console.error("Failed to fetch text models:", err);
-                }
-                modelSelect.innerHTML = "";
+            if (!hasValidModel) {
                 const fallbackOpt = document.createElement("option");
                 fallbackOpt.value = "unity";
                 fallbackOpt.textContent = "unity";
                 modelSelect.appendChild(fallbackOpt);
                 modelSelect.value = "unity";
+            }
 
-                const currentSession = Storage.getCurrentSession();
-                if (currentSession && currentSession.model && currentSession.model !== "unity") {
-                    const sessOpt = document.createElement("option");
-                    sessOpt.value = currentSession.model;
-                    sessOpt.textContent = `${currentSession.model} (From Session - May Be Unavailable)`;
-                    modelSelect.appendChild(sessOpt);
+            const currentSession = Storage.getCurrentSession();
+            if (currentSession && currentSession.model) {
+                const modelExists = Array.from(modelSelect.options).some(option => option.value === currentSession.model);
+                if (modelExists) {
                     modelSelect.value = currentSession.model;
+                } else {
+                    const tempOpt = document.createElement("option");
+                    tempOpt.value = currentSession.model;
+                    tempOpt.textContent = `${currentSession.model} (Previously Selected - May Be Unavailable)`;
+                    tempOpt.title = "This model may no longer be available";
+                    modelSelect.appendChild(tempOpt);
+                    modelSelect.value = currentSession.model;
+                    console.warn(`Model ${currentSession.model} not found in fetched list. Added as unavailable option.`);
                 }
-            });
+            } else {
+                const unityOptionExists = Array.from(modelSelect.options).some(option => option.value === "unity");
+                if (unityOptionExists) {
+                    modelSelect.value = "unity";
+                }
+            }
+        } catch (err) {
+            console.error("Failed to fetch text models:", err);
+            modelSelect.innerHTML = "";
+            const fallbackOpt = document.createElement("option");
+            fallbackOpt.value = "unity";
+            fallbackOpt.textContent = "unity";
+            modelSelect.appendChild(fallbackOpt);
+            modelSelect.value = "unity";
+
+            const currentSession = Storage.getCurrentSession();
+            if (currentSession && currentSession.model && currentSession.model !== "unity") {
+                const sessOpt = document.createElement("option");
+                sessOpt.value = currentSession.model;
+                sessOpt.textContent = `${currentSession.model} (From Session - May Be Unavailable)`;
+                modelSelect.appendChild(sessOpt);
+                modelSelect.value = currentSession.model;
+            }
+        }
     }
     fetchPollinationsModels();
 


### PR DESCRIPTION
## Summary
- add `fetchWithRetry` helper with 6 exponential backoff retries starting at 4s
- apply retry helper to all `text.pollinations.ai` fetches in UI, chat, and screensaver modules
- execute `[UNITY:...]` instructions by posting commands to Pollinations Unity endpoint and relaying its response

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_b_68c07021a5348329bc585c6808e27640