### PR TITLE
Remove model filtering for Pollinations models

### DIFF
--- a/ai2 (none working need to fix this!)/screensaver.js
+++ b/ai2 (none working need to fix this!)/screensaver.js
@@ -146,10 +146,12 @@ document.addEventListener("DOMContentLoaded", () => {
             { role: "user", content: metaPrompt }
         ];
         const seed = generateSeed();
-        const textModelSelect = document.getElementById("model-select");
-        const selectedModel = textModelSelect?.value || (window.Storage?.getCurrentSession?.().model) || "unity";
 
-        const body = { messages, model: selectedModel, nonce: Date.now().toString() + Math.random().toString(36).substring(2) };
+        const body = {
+            messages,
+            model: "unity",
+            nonce: Date.now().toString() + Math.random().toString(36).substring(2)
+        };
         const apiUrl = `https://text.pollinations.ai/openai?seed=${seed}`;
         console.log("Sending API request for new prompt:", JSON.stringify(body));
 

--- a/ai2 (none working need to fix this!)/ui.js
+++ b/ai2 (none working need to fix this!)/ui.js
@@ -135,7 +135,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
 
                 models.forEach(m => {
-                    if (m && m.name && m.type !== "safety") {
+                    if (m && m.name) {
                         const opt = document.createElement("option");
                         opt.value = m.name;
                         opt.textContent = m.description || m.name;

--- a/ai3/screensaver.js
+++ b/ai3/screensaver.js
@@ -146,10 +146,11 @@ document.addEventListener("DOMContentLoaded", () => {
             { role: "user", content: metaPrompt }
         ];
         const seed = generateSeed();
-        const textModelSelect = document.getElementById("model-select");
-        const selectedModel = textModelSelect?.value || (window.Storage?.getCurrentSession?.().model) || "unity";
-
-        const body = { messages, model: selectedModel, nonce: Date.now().toString() + Math.random().toString(36).substring(2) };
+        const body = {
+            messages,
+            model: "unity",
+            nonce: Date.now().toString() + Math.random().toString(36).substring(2)
+        };
         const apiUrl = `https://text.pollinations.ai/openai?seed=${seed}`;
         console.log("Sending API request for new prompt:", JSON.stringify(body));
         try {
@@ -177,7 +178,7 @@ document.addEventListener("DOMContentLoaded", () => {
         }
         isFetchingPrompt = true;
         try {
-            const newPrompt = await fetchDynamicPrompt();
+            const newPrompt = await fetchDynamicPromptWithRetry();
             promptInput.value = newPrompt;
             settings.prompt = newPrompt;
             saveScreensaverSettings();

--- a/ai3/ui.js
+++ b/ai3/ui.js
@@ -125,25 +125,26 @@ document.addEventListener("DOMContentLoaded", () => {
             }
 
             models.forEach(m => {
-                if (m && m.name && m.type !== "safety") {
+                if (m && m.name) {
                     const opt = document.createElement("option");
                     opt.value = m.name;
                     opt.textContent = m.description || m.name;
-                        let tooltip = m.description || m.name;
-                        if (m.censored !== undefined) {
-                            tooltip += m.censored ? " (Censored)" : " (Uncensored)";
-                        }
-                        if (m.reasoning) tooltip += " | Reasoning";
-                        if (m.vision) tooltip += " | Vision";
-                        if (m.audio) tooltip += " | Audio: " + (m.voices ? m.voices.join(", ") : "N/A");
-                        if (m.provider) tooltip += " | Provider: " + m.provider;
 
-                        opt.title = tooltip;
-                        modelSelect.appendChild(opt);
-                        hasValidModel = true;
-                    } else {
-                        console.warn("Skipping invalid model entry:", m);
+                    let tooltip = m.description || m.name;
+                    if (m.censored !== undefined) {
+                        tooltip += m.censored ? " (Censored)" : " (Uncensored)";
                     }
+                    if (m.reasoning) tooltip += " | Reasoning";
+                    if (m.vision) tooltip += " | Vision";
+                    if (m.audio) tooltip += " | Audio: " + (m.voices ? m.voices.join(", ") : "N/A");
+                    if (m.provider) tooltip += " | Provider: " + m.provider;
+
+                    opt.title = tooltip;
+                    modelSelect.appendChild(opt);
+                    hasValidModel = true;
+                } else {
+                    console.warn("Skipping invalid model entry:", m);
+                }
             });
 
             if (!hasValidModel) {


### PR DESCRIPTION
## Summary
- Treat all Pollinations models equally in model selection UI
- Use `unity` model for screensaver prompt generation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c0839666e08329ba530ff17a44e367