### PR TITLE
Remove model filtering for Pollinations models

### DIFF
--- a/ai2 (none working need to fix this!)/chat-init.js
+++ b/ai2 (none working need to fix this!)/chat-init.js
@@ -519,9 +519,9 @@ document.addEventListener("DOMContentLoaded", () => {
         const selectedModel = modelSelect.value || currentSession.model || "unity";
         const nonce = Date.now().toString() + Math.random().toString(36).substring(2);
         const body = { messages, model: selectedModel, nonce };
-        const apiUrl = `https://text.pollinations.ai/openai`;
+        const apiUrl = `https://text.pollinations.ai/${encodeURIComponent(selectedModel)}`;
         console.log("Sending API request with payload:", JSON.stringify(body));
-        fetch(apiUrl, {
+        window.pollinationsFetch(apiUrl, {
             method: "POST",
             headers: { "Content-Type": "application/json", Accept: "application/json" },
             body: JSON.stringify(body),

--- a/ai2 (none working need to fix this!)/chat-storage.js
+++ b/ai2 (none working need to fix this!)/chat-storage.js
@@ -553,9 +553,9 @@ document.addEventListener("DOMContentLoaded", () => {
         const selectedModel = modelSelect.value || currentSession.model || "unity";
         const nonce = Date.now().toString() + Math.random().toString(36).substring(2);
         const body = { messages, model: selectedModel, nonce };
-        const apiUrl = `https://text.pollinations.ai/openai`;
+        const apiUrl = `https://text.pollinations.ai/${encodeURIComponent(selectedModel)}`;
         console.log("Sending API request with payload:", JSON.stringify(body));
-        fetch(apiUrl, {
+        window.pollinationsFetch(apiUrl, {
             method: "POST",
             headers: { "Content-Type": "application/json", Accept: "application/json" },
             body: JSON.stringify(body),

--- a/ai2 (none working need to fix this!)/screensaver.js
+++ b/ai2 (none working need to fix this!)/screensaver.js
@@ -146,10 +146,12 @@ document.addEventListener("DOMContentLoaded", () => {
             { role: "user", content: metaPrompt }
         ];
         const seed = generateSeed();
-        const textModelSelect = document.getElementById("model-select");
-        const selectedModel = textModelSelect?.value || (window.Storage?.getCurrentSession?.().model) || "unity";
 
-        const body = { messages, model: selectedModel, nonce: Date.now().toString() + Math.random().toString(36).substring(2) };
+        const body = {
+            messages,
+            model: "unity",
+            nonce: Date.now().toString() + Math.random().toString(36).substring(2)
+        };
         const apiUrl = `https://text.pollinations.ai/openai?seed=${seed}`;
         console.log("Sending API request for new prompt:", JSON.stringify(body));
 

--- a/ai2 (none working need to fix this!)/ui.js
+++ b/ai2 (none working need to fix this!)/ui.js
@@ -108,107 +108,91 @@ document.addEventListener("DOMContentLoaded", () => {
         changeTheme(themeSelectSettings.value);
     });
 
-    function fetchPollinationsModels() {
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 5000);
+    async function fetchPollinationsModels() {
+        try {
+            const res = await window.pollinationsFetch("https://text.pollinations.ai/models", {
+                method: "GET",
+                headers: { "Content-Type": "application/json" },
+                cache: "no-store"
+            });
+            const models = await res.json();
+            modelSelect.innerHTML = "";
+            let hasValidModel = false;
 
-        fetch("https://text.pollinations.ai/models", {
-            method: "GET",
-            headers: { "Content-Type": "application/json" },
-            cache: "no-store",
-            signal: controller.signal
-        })
-            .then(res => {
-                clearTimeout(timeoutId);
-                if (!res.ok) {
-                    throw new Error(`HTTP error! Status: ${res.status}`);
-                }
-                return res.json();
-            })
-            .then(models => {
-                modelSelect.innerHTML = "";
-                let hasValidModel = false;
+            if (!Array.isArray(models) || models.length === 0) {
+                console.error("Models response is not a valid array or is empty:", models);
+                throw new Error("Invalid models response");
+            }
 
-                if (!Array.isArray(models) || models.length === 0) {
-                    console.error("Models response is not a valid array or is empty:", models);
-                    throw new Error("Invalid models response");
-                }
+            models.forEach(m => {
+                if (m && m.name) {
+                    const opt = document.createElement("option");
+                    opt.value = m.name;
+                    opt.textContent = m.description || m.name;
 
-                models.forEach(m => {
-                    if (m && m.name && m.type !== "safety") {
-                        const opt = document.createElement("option");
-                        opt.value = m.name;
-                        opt.textContent = m.description || m.name;
-
-                        let tooltip = m.description || m.name;
-                        if (m.censored !== undefined) {
-                            tooltip += m.censored ? " (Censored)" : " (Uncensored)";
-                        }
-                        if (m.reasoning) tooltip += " | Reasoning";
-                        if (m.vision) tooltip += " | Vision";
-                        if (m.audio) tooltip += " | Audio: " + (m.voices ? m.voices.join(", ") : "N/A");
-                        if (m.provider) tooltip += " | Provider: " + m.provider;
-
-                        opt.title = tooltip;
-                        modelSelect.appendChild(opt);
-                        hasValidModel = true;
-                    } else {
-                        console.warn("Skipping invalid model entry:", m);
+                    let tooltip = m.description || m.name;
+                    if (m.censored !== undefined) {
+                        tooltip += m.censored ? " (Censored)" : " (Uncensored)";
                     }
-                });
+                    if (m.reasoning) tooltip += " | Reasoning";
+                    if (m.vision) tooltip += " | Vision";
+                    if (m.audio) tooltip += " | Audio: " + (m.voices ? m.voices.join(", ") : "N/A");
+                    if (m.provider) tooltip += " | Provider: " + m.provider;
 
-                if (!hasValidModel) {
-                    const fallbackOpt = document.createElement("option");
-                    fallbackOpt.value = "unity";
-                    fallbackOpt.textContent = "unity";
-                    modelSelect.appendChild(fallbackOpt);
-                    modelSelect.value = "unity";
-                }
-
-                const currentSession = Storage.getCurrentSession();
-                if (currentSession && currentSession.model) {
-                    const modelExists = Array.from(modelSelect.options).some(option => option.value === currentSession.model);
-                    if (modelExists) {
-                        modelSelect.value = currentSession.model;
-                    } else {
-                        const tempOpt = document.createElement("option");
-                        tempOpt.value = currentSession.model;
-                        tempOpt.textContent = `${currentSession.model} (Previously Selected - May Be Unavailable)`;
-                        tempOpt.title = "This model may no longer be available";
-                        modelSelect.appendChild(tempOpt);
-                        modelSelect.value = currentSession.model;
-                        console.warn(`Model ${currentSession.model} not found in fetched list. Added as unavailable option.`);
-                    }
+                    opt.title = tooltip;
+                    modelSelect.appendChild(opt);
+                    hasValidModel = true;
                 } else {
-                    const unityOptionExists = Array.from(modelSelect.options).some(option => option.value === "unity");
-                    if (unityOptionExists) {
-                        modelSelect.value = "unity";
-                    }
+                    console.warn("Skipping invalid model entry:", m);
                 }
-            })
-            .catch(err => {
-                clearTimeout(timeoutId);
-                if (err.name === "AbortError") {
-                    console.error("Fetch timed out");
-                } else {
-                    console.error("Failed to fetch text models:", err);
-                }
-                modelSelect.innerHTML = "";
+            });
+
+            if (!hasValidModel) {
                 const fallbackOpt = document.createElement("option");
                 fallbackOpt.value = "unity";
                 fallbackOpt.textContent = "unity";
                 modelSelect.appendChild(fallbackOpt);
                 modelSelect.value = "unity";
+            }
 
-                const currentSession = Storage.getCurrentSession();
-                if (currentSession && currentSession.model && currentSession.model !== "unity") {
-                    const sessOpt = document.createElement("option");
-                    sessOpt.value = currentSession.model;
-                    sessOpt.textContent = `${currentSession.model} (From Session - May Be Unavailable)`;
-                    modelSelect.appendChild(sessOpt);
+            const currentSession = Storage.getCurrentSession();
+            if (currentSession && currentSession.model) {
+                const modelExists = Array.from(modelSelect.options).some(option => option.value === currentSession.model);
+                if (modelExists) {
                     modelSelect.value = currentSession.model;
+                } else {
+                    const tempOpt = document.createElement("option");
+                    tempOpt.value = currentSession.model;
+                    tempOpt.textContent = `${currentSession.model} (Previously Selected - May Be Unavailable)`;
+                    tempOpt.title = "This model may no longer be available";
+                    modelSelect.appendChild(tempOpt);
+                    modelSelect.value = currentSession.model;
+                    console.warn(`Model ${currentSession.model} not found in fetched list. Added as unavailable option.`);
                 }
-            });
+            } else {
+                const unityOptionExists = Array.from(modelSelect.options).some(option => option.value === "unity");
+                if (unityOptionExists) {
+                    modelSelect.value = "unity";
+                }
+            }
+        } catch (err) {
+            console.error("Failed to fetch text models:", err);
+            modelSelect.innerHTML = "";
+            const fallbackOpt = document.createElement("option");
+            fallbackOpt.value = "unity";
+            fallbackOpt.textContent = "unity";
+            modelSelect.appendChild(fallbackOpt);
+            modelSelect.value = "unity";
+
+            const currentSession = Storage.getCurrentSession();
+            if (currentSession && currentSession.model && currentSession.model !== "unity") {
+                const sessOpt = document.createElement("option");
+                sessOpt.value = currentSession.model;
+                sessOpt.textContent = `${currentSession.model} (From Session - May Be Unavailable)`;
+                modelSelect.appendChild(sessOpt);
+                modelSelect.value = currentSession.model;
+            }
+        }
     }
     fetchPollinationsModels();
 

--- a/ai3/chat-init.js
+++ b/ai3/chat-init.js
@@ -519,7 +519,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const selectedModel = modelSelect.value || currentSession.model || "unity";
         const nonce = Date.now().toString() + Math.random().toString(36).substring(2);
         const body = { messages, model: selectedModel, nonce };
-        const apiUrl = `https://text.pollinations.ai/openai`;
+        const apiUrl = `https://text.pollinations.ai/${encodeURIComponent(selectedModel)}`;
         console.log("Sending API request with payload:", JSON.stringify(body));
         window.pollinationsFetch(apiUrl, {
             method: "POST",

--- a/ai3/chat-storage.js
+++ b/ai3/chat-storage.js
@@ -553,7 +553,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const selectedModel = modelSelect.value || currentSession.model || "unity";
         const nonce = Date.now().toString() + Math.random().toString(36).substring(2);
         const body = { messages, model: selectedModel, nonce };
-        const apiUrl = `https://text.pollinations.ai/openai`;
+        const apiUrl = `https://text.pollinations.ai/${encodeURIComponent(selectedModel)}`;
         console.log("Sending API request with payload:", JSON.stringify(body));
         window.pollinationsFetch(apiUrl, {
             method: "POST",

--- a/ai3/screensaver.js
+++ b/ai3/screensaver.js
@@ -146,10 +146,11 @@ document.addEventListener("DOMContentLoaded", () => {
             { role: "user", content: metaPrompt }
         ];
         const seed = generateSeed();
-        const textModelSelect = document.getElementById("model-select");
-        const selectedModel = textModelSelect?.value || (window.Storage?.getCurrentSession?.().model) || "unity";
-
-        const body = { messages, model: selectedModel, nonce: Date.now().toString() + Math.random().toString(36).substring(2) };
+        const body = {
+            messages,
+            model: "unity",
+            nonce: Date.now().toString() + Math.random().toString(36).substring(2)
+        };
         const apiUrl = `https://text.pollinations.ai/openai?seed=${seed}`;
         console.log("Sending API request for new prompt:", JSON.stringify(body));
         try {
@@ -177,7 +178,7 @@ document.addEventListener("DOMContentLoaded", () => {
         }
         isFetchingPrompt = true;
         try {
-            const newPrompt = await fetchDynamicPrompt();
+            const newPrompt = await fetchDynamicPromptWithRetry();
             promptInput.value = newPrompt;
             settings.prompt = newPrompt;
             saveScreensaverSettings();

--- a/ai3/ui.js
+++ b/ai3/ui.js
@@ -125,25 +125,26 @@ document.addEventListener("DOMContentLoaded", () => {
             }
 
             models.forEach(m => {
-                if (m && m.name && m.type !== "safety") {
+                if (m && m.name) {
                     const opt = document.createElement("option");
                     opt.value = m.name;
                     opt.textContent = m.description || m.name;
-                        let tooltip = m.description || m.name;
-                        if (m.censored !== undefined) {
-                            tooltip += m.censored ? " (Censored)" : " (Uncensored)";
-                        }
-                        if (m.reasoning) tooltip += " | Reasoning";
-                        if (m.vision) tooltip += " | Vision";
-                        if (m.audio) tooltip += " | Audio: " + (m.voices ? m.voices.join(", ") : "N/A");
-                        if (m.provider) tooltip += " | Provider: " + m.provider;
 
-                        opt.title = tooltip;
-                        modelSelect.appendChild(opt);
-                        hasValidModel = true;
-                    } else {
-                        console.warn("Skipping invalid model entry:", m);
+                    let tooltip = m.description || m.name;
+                    if (m.censored !== undefined) {
+                        tooltip += m.censored ? " (Censored)" : " (Uncensored)";
                     }
+                    if (m.reasoning) tooltip += " | Reasoning";
+                    if (m.vision) tooltip += " | Vision";
+                    if (m.audio) tooltip += " | Audio: " + (m.voices ? m.voices.join(", ") : "N/A");
+                    if (m.provider) tooltip += " | Provider: " + m.provider;
+
+                    opt.title = tooltip;
+                    modelSelect.appendChild(opt);
+                    hasValidModel = true;
+                } else {
+                    console.warn("Skipping invalid model entry:", m);
+                }
             });
 
             if (!hasValidModel) {


### PR DESCRIPTION
## Summary
- Treat all Pollinations models equally in model selection UI
- Use `unity` model for screensaver prompt generation
- Send chat requests to model-specific Pollinations endpoints

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c0839666e08329ba530ff17a44e367