### PR TITLE
Allow Pollinations models to use default safety

### DIFF
--- a/ai3/chat-core.js
+++ b/ai3/chat-core.js
@@ -1,6 +1,6 @@
-// Global config for Pollinations API settings (safe mode and token)
+// Global config for Pollinations API settings (e.g., auth token)
+// Leaving `safe` unset ensures models use their default safety behavior.
 window._pollinationsAPIConfig = window._pollinationsAPIConfig || {
-    safe: false,
     // Token can be provided via process.env or a global variable set in a separate script.
     token:
         (typeof process !== "undefined" && process.env?.POLLINATIONS_TOKEN) ||
@@ -9,15 +9,12 @@ window._pollinationsAPIConfig = window._pollinationsAPIConfig || {
 };
 
 // Global helper to retry Pollinations text API requests with exponential backoff.
-// Automatically appends `safe` and `token` query parameters if not present.
+// Automatically appends a `token` query parameter if provided.
 window.pollinationsFetch = async function (url, options = {}, retries = 6, delay = 4000) {
     const cfg = window._pollinationsAPIConfig || {};
     try {
         const urlObj = new URL(url);
         if (urlObj.hostname.includes("pollinations.ai")) {
-            if (cfg.safe !== undefined && !urlObj.searchParams.has("safe")) {
-                urlObj.searchParams.set("safe", cfg.safe ? "true" : "false");
-            }
             const token =
                 cfg.token ||
                 (typeof process !== "undefined" && process.env?.POLLINATIONS_TOKEN) ||


### PR DESCRIPTION
## Summary
- avoid forcing the `safe` flag on every Pollinations request
- document that leaving `safe` unset allows models to handle safety on their own

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c09038d7748329853f9db5f0692384