### PR TITLE
Handle missing Pollinations token gracefully

### DIFF
--- a/ai3/chat-core.js
+++ b/ai3/chat-core.js
@@ -693,7 +693,8 @@ document.addEventListener("DOMContentLoaded", () => {
         const selectedModel = modelSelect.value || currentSession.model || "openai";
         const nonce = Date.now().toString() + Math.random().toString(36).substring(2);
         const body = { messages, model: selectedModel, nonce };
-        const apiUrl = `https://text.pollinations.ai/openai/${encodeURIComponent(selectedModel)}?token=${POLLINATIONS_TOKEN}`;
+        const tokenQuery = POLLINATIONS_TOKEN ? `?token=${POLLINATIONS_TOKEN}` : "";
+        const apiUrl = `https://text.pollinations.ai/openai/${encodeURIComponent(selectedModel)}${tokenQuery}`;
         console.log("Sending API request with payload:", JSON.stringify(body));
         fetch(apiUrl, {
             method: "POST",

--- a/ai3/screensaver.js
+++ b/ai3/screensaver.js
@@ -172,7 +172,8 @@ document.addEventListener("DOMContentLoaded", () => {
             model: "unity",
             nonce: Date.now().toString() + Math.random().toString(36).substring(2)
         };
-        const apiUrl = `https://text.pollinations.ai/openai/${encodeURIComponent(body.model)}?token=${POLLINATIONS_TOKEN}&seed=${seed}`;
+        const tokenParam = POLLINATIONS_TOKEN ? `token=${POLLINATIONS_TOKEN}&` : "";
+        const apiUrl = `https://text.pollinations.ai/openai/${encodeURIComponent(body.model)}?${tokenParam}seed=${seed}`;
         console.log("Sending API request for new prompt:", JSON.stringify(body));
         try {
             const response = await fetch(apiUrl, {

--- a/ai3/ui.js
+++ b/ai3/ui.js
@@ -130,7 +130,7 @@ document.addEventListener("DOMContentLoaded", () => {
     // or returns invalid data.
     async function fetchPollinationsModels() {
         try {
-            const url = `https://text.pollinations.ai/models?token=${POLLINATIONS_TOKEN}`;
+            const url = `https://text.pollinations.ai/models${POLLINATIONS_TOKEN ? `?token=${POLLINATIONS_TOKEN}` : ""}`;
             const res = await fetch(url, {
                 method: "GET",
                 headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- Avoid sending `token=undefined` in Pollinations requests for chat, model list, and screensaver features
- Build API URLs conditionally when a token is provided

## Testing
- `node --check ai3/chat-core.js`
- `node --check ai3/screensaver.js`
- `node --check ai3/ui.js`
- `npm test` *(fails: ENOENT missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c2487480448329a7e1fbf37fce948b