### PR TITLE
Default Unity text model and query parameter

### DIFF
--- a/ai3/chat-core.js
+++ b/ai3/chat-core.js
@@ -690,11 +690,13 @@ document.addEventListener("DOMContentLoaded", () => {
             lastUserMsg.includes("picture") ||
             imagePatterns.some(p => p.pattern.test(lastUserMsg))
         );
-        const selectedModel = modelSelect.value || currentSession.model || "openai";
+        const selectedModel = modelSelect.value || currentSession.model || "unity";
         const nonce = Date.now().toString() + Math.random().toString(36).substring(2);
         const body = { messages, model: selectedModel, nonce };
-        const tokenQuery = POLLINATIONS_TOKEN ? `?token=${POLLINATIONS_TOKEN}` : "";
-        const apiUrl = `https://text.pollinations.ai/openai/${encodeURIComponent(selectedModel)}${tokenQuery}`;
+        const params = new URLSearchParams();
+        if (POLLINATIONS_TOKEN) params.set("token", POLLINATIONS_TOKEN);
+        params.set("model", selectedModel);
+        const apiUrl = `https://text.pollinations.ai/openai?${params.toString()}`;
         console.log("Sending API request with payload:", JSON.stringify(body));
         fetch(apiUrl, {
             method: "POST",

--- a/ai3/screensaver.js
+++ b/ai3/screensaver.js
@@ -172,8 +172,11 @@ document.addEventListener("DOMContentLoaded", () => {
             model: "unity",
             nonce: Date.now().toString() + Math.random().toString(36).substring(2)
         };
-        const tokenParam = POLLINATIONS_TOKEN ? `token=${POLLINATIONS_TOKEN}&` : "";
-        const apiUrl = `https://text.pollinations.ai/openai/${encodeURIComponent(body.model)}?${tokenParam}seed=${seed}`;
+        const params = new URLSearchParams();
+        if (POLLINATIONS_TOKEN) params.set("token", POLLINATIONS_TOKEN);
+        params.set("model", body.model);
+        params.set("seed", seed);
+        const apiUrl = `https://text.pollinations.ai/openai?${params.toString()}`;
         console.log("Sending API request for new prompt:", JSON.stringify(body));
         try {
             const response = await fetch(apiUrl, {

--- a/ai3/storage.js
+++ b/ai3/storage.js
@@ -9,7 +9,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const sessionListEl = document.getElementById("session-list");
   let sessions = loadSessions();
-  const defaultModelPreference = localStorage.getItem("defaultModelPreference") || "openai";
+  const defaultModelPreference = localStorage.getItem("defaultModelPreference") || "unity";
 
   if (!localStorage.getItem("currentSessionId")) {
     const newSession = createSession("New Chat");
@@ -49,11 +49,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   /**
    * Get the default model to use for new sessions. If the user has not
-   * chosen one yet, "openai" is returned.
+   * chosen one yet, "unity" is returned.
    * @returns {string} model identifier
    */
   function getDefaultModel() {
-    return localStorage.getItem("defaultModelPreference") || "openai";
+    return localStorage.getItem("defaultModelPreference") || "unity";
   }
 
   /**

--- a/ai3/ui.js
+++ b/ai3/ui.js
@@ -172,10 +172,10 @@ document.addEventListener("DOMContentLoaded", () => {
             // If no valid models were returned, provide a sane fallback.
             if (!hasValidModel) {
                 const fallbackOpt = document.createElement("option");
-                fallbackOpt.value = "openai";
-                fallbackOpt.textContent = "openai";
+                fallbackOpt.value = "unity";
+                fallbackOpt.textContent = "unity";
                 modelSelect.appendChild(fallbackOpt);
-                modelSelect.value = "openai";
+                modelSelect.value = "unity";
             }
 
             // Preserve the model from the current session if possible.
@@ -194,22 +194,22 @@ document.addEventListener("DOMContentLoaded", () => {
                     console.warn(`Model ${currentSession.model} not found in fetched list. Added as unavailable option.`);
                 }
             } else {
-                const defaultOptionExists = Array.from(modelSelect.options).some(option => option.value === "openai");
+                const defaultOptionExists = Array.from(modelSelect.options).some(option => option.value === "unity");
                 if (defaultOptionExists) {
-                    modelSelect.value = "openai";
+                    modelSelect.value = "unity";
                 }
             }
         } catch (err) {
             console.error("Failed to fetch text models:", err);
             modelSelect.innerHTML = "";
             const fallbackOpt = document.createElement("option");
-            fallbackOpt.value = "openai";
-            fallbackOpt.textContent = "openai";
+            fallbackOpt.value = "unity";
+            fallbackOpt.textContent = "unity";
             modelSelect.appendChild(fallbackOpt);
-            modelSelect.value = "openai";
+            modelSelect.value = "unity";
 
             const currentSession = Storage.getCurrentSession();
-            if (currentSession && currentSession.model && currentSession.model !== "openai") {
+            if (currentSession && currentSession.model && currentSession.model !== "unity") {
                 const sessOpt = document.createElement("option");
                 sessOpt.value = currentSession.model;
                 sessOpt.textContent = `${currentSession.model} (From Session - May Be Unavailable)`;


### PR DESCRIPTION
## Summary
- Pass the selected text model as a `model` query parameter when calling Pollinations API
- Default to `unity` model on startup and remember user selection
- Align screensaver prompt generation with new model parameter approach

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c24b8585488329bce60d22d4695ab8