### PR TITLE
Include model, token, and seed in Pollinations API calls

### DIFF
--- a/ai3/chat-core.js
+++ b/ai3/chat-core.js
@@ -692,10 +692,12 @@ document.addEventListener("DOMContentLoaded", () => {
         );
         const selectedModel = modelSelect.value || currentSession.model || "unity";
         const nonce = Date.now().toString() + Math.random().toString(36).substring(2);
+        const seed = randomSeed();
         const body = { messages, model: selectedModel, nonce };
         const params = new URLSearchParams();
-        if (POLLINATIONS_TOKEN) params.set("token", POLLINATIONS_TOKEN);
+        params.set("token", POLLINATIONS_TOKEN || "");
         params.set("model", selectedModel);
+        params.set("seed", seed);
         const apiUrl = `https://text.pollinations.ai/openai?${params.toString()}`;
         console.log("Sending API request with payload:", JSON.stringify(body));
         fetch(apiUrl, {

--- a/ai3/screensaver.js
+++ b/ai3/screensaver.js
@@ -167,13 +167,14 @@ document.addEventListener("DOMContentLoaded", () => {
             { role: "user", content: metaPrompt }
         ];
         const seed = generateSeed();
+        const textModelSelect = document.getElementById("model-select");
         const body = {
             messages,
-            model: "unity",
+            model: textModelSelect ? textModelSelect.value : "unity",
             nonce: Date.now().toString() + Math.random().toString(36).substring(2)
         };
         const params = new URLSearchParams();
-        if (POLLINATIONS_TOKEN) params.set("token", POLLINATIONS_TOKEN);
+        params.set("token", POLLINATIONS_TOKEN || "");
         params.set("model", body.model);
         params.set("seed", seed);
         const apiUrl = `https://text.pollinations.ai/openai?${params.toString()}`;

--- a/ai3/ui.js
+++ b/ai3/ui.js
@@ -130,7 +130,7 @@ document.addEventListener("DOMContentLoaded", () => {
     // or returns invalid data.
     async function fetchPollinationsModels() {
         try {
-            const url = `https://text.pollinations.ai/models${POLLINATIONS_TOKEN ? `?token=${POLLINATIONS_TOKEN}` : ""}`;
+            const url = `https://text.pollinations.ai/models?token=${POLLINATIONS_TOKEN || ""}`;
             const res = await fetch(url, {
                 method: "GET",
                 headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- Add seed and token parameters to Pollinations text API requests and ensure model is set explicitly
- Allow screensaver prompt generation to use selected chat model
- Always include token when fetching model list

## Testing
- `npm test` *(fails: ENOENT no such file package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c251d7e3e0832995b44bdc2a3fd885